### PR TITLE
Making the success result language independent (Addressing #3)

### DIFF
--- a/keepass4brute.sh
+++ b/keepass4brute.sh
@@ -6,7 +6,7 @@
 # Version: 1.0 (25/11/2022)
 
 version="1.1"
-/bin/echo -e "\nkeepass4brute $version by r3nt0n"
+/bin/echo -e "keepass4brute $version by r3nt0n"
 /bin/echo -e "https://github.com/r3nt0n/keepass4brute\n"
 
 
@@ -27,7 +27,8 @@ while read -r line; do
   n_tested=$((n_tested + 1))
   /bin/echo -ne "[+] Words tested: $n_tested/$n_total ($line)                                          \r"
 
-  if ! /bin/echo $line | keepassxc-cli open $1 2>&1 | /bin/grep -q "Error"
+  /bin/echo $line | keepassxc-cli open $1 &> /dev/null
+  if [ $? -eq 0 ]
   then
     /bin/echo -ne "\n"
     /bin/echo "[*] Password found: $line"; exit 0;


### PR DESCRIPTION
Changing the way that successful passwords are being detected,  taking the return value from the command instead of grep for an specific word, which can vary depending on the language configured on the system. 

Credits to @kolet , @zorddy and @marvinxyz for reporting and helping to detect the issue.

Additional minor visual change to banner.