### PR TITLE
add estimated time remaining status

### DIFF
--- a/keepass4brute.sh
+++ b/keepass4brute.sh
@@ -73,4 +73,4 @@ while read -r line; do
 done < $2
 
 /bin/echo -ne "\n"
-/bin/echo "[!] Wordlist exhausted, any match found"; exit 3;
+/bin/echo "[!] Wordlist exhausted, no match found"; exit 3;

--- a/keepass4brute.sh
+++ b/keepass4brute.sh
@@ -5,10 +5,9 @@
 # Author: r3nt0n
 # Version: 1.0 (25/11/2022)
 
-version="1.1"
+version="1.3"
 /bin/echo -e "keepass4brute $version by r3nt0n"
 /bin/echo -e "https://github.com/r3nt0n/keepass4brute\n"
-
 
 if [ $# -ne 2 ]
 then
@@ -20,19 +19,57 @@ dep="keepassxc-cli"
 command -v $dep >/dev/null 2>&1 || { /bin/echo >&2 "Error: $dep not installed.  Aborting."; exit 1; }
 
 n_total=$( wc -l < $2 )
-n_tested=0
+start_time=$(date +%s)
 
 IFS=''
 while read -r line; do
   n_tested=$((n_tested + 1))
-  /bin/echo -ne "[+] Words tested: $n_tested/$n_total ($line)                                          \r"
+  current_time=$(date +%s)
+  elapsed_time=$((current_time - start_time))
 
+  if [ $elapsed_time -gt 0 ]; then
+    attempts_per_minute=$((n_tested * 60 / elapsed_time))
+    remaining_attempts=$((n_total - n_tested))
+    estimated_time_remaining_seconds=$((remaining_attempts * 60 / attempts_per_minute))
+    
+    estimated_time_remaining_minutes=$((estimated_time_remaining_seconds / 60))
+    estimated_time_remaining_seconds=$((estimated_time_remaining_seconds % 60))
+
+    estimated_time_remaining_hours=$((estimated_time_remaining_minutes / 60))
+    estimated_time_remaining_minutes=$((estimated_time_remaining_minutes % 60))
+
+    estimated_time_remaining_days=$((estimated_time_remaining_hours / 24))
+    estimated_time_remaining_hours=$((estimated_time_remaining_hours % 24))
+
+    estimated_time_remaining_weeks=$((estimated_time_remaining_days / 7))
+    estimated_time_remaining_days=$((estimated_time_remaining_days % 7))
+
+    if [ $estimated_time_remaining_weeks -gt 0 ]; then
+      estimated_time_remaining="$estimated_time_remaining_weeks weeks, $estimated_time_remaining_days days"
+    elif [ $estimated_time_remaining_days -gt 0 ]; then
+      estimated_time_remaining="$estimated_time_remaining_days days, $estimated_time_remaining_hours hours"
+    elif [ $estimated_time_remaining_hours -gt 0 ]; then
+      estimated_time_remaining="$estimated_time_remaining_hours hours, $estimated_time_remaining_minutes minutes"
+    elif [ $estimated_time_remaining_minutes -gt 0 ]; then
+      estimated_time_remaining="$estimated_time_remaining_minutes minutes, $estimated_time_remaining_seconds seconds"
+    else
+      estimated_time_remaining="$estimated_time_remaining_seconds seconds"
+    fi
+  else
+    attempts_per_minute=0
+    estimated_time_remaining="Calculating..."
+  fi
+
+  /bin/echo -e "\e[2K\r[+] Words tested: $n_tested/$n_total - Attempts per minute: $attempts_per_minute - Estimated time remaining: $estimated_time_remaining"
+  /bin/echo -e "\e[2K\r[+] Current attempt: $line"
+  
   /bin/echo $line | keepassxc-cli open $1 &> /dev/null
   if [ $? -eq 0 ]
   then
     /bin/echo -ne "\n"
     /bin/echo "[*] Password found: $line"; exit 0;
   fi
+  /bin/echo -ne "\e[2A"
 done < $2
 
 /bin/echo -ne "\n"


### PR DESCRIPTION
Added an estimate of the remaining time to process the wordlist, calculated based on the current attempts per minute.

![image copy 3](https://github.com/user-attachments/assets/8b2964b6-ee82-439c-9756-3301caef62a8)

![image copy](https://github.com/user-attachments/assets/1be059fe-127d-4451-b6c5-646ef0e3254e)
![image copy 2](https://github.com/user-attachments/assets/3992250f-6fc3-4806-9ab2-5e5478740350)

![image copy 4](https://github.com/user-attachments/assets/e24618fe-2275-400e-86f1-ef0d4335032b)
![image](https://github.com/user-attachments/assets/beb6c6a2-f0af-4260-8859-d6d0883cc810)
